### PR TITLE
Fix incorrect torch usage

### DIFF
--- a/src/main/java/org/razordevs/ascended_quark/entity/AmbrosiumTorchArrow.java
+++ b/src/main/java/org/razordevs/ascended_quark/entity/AmbrosiumTorchArrow.java
@@ -79,7 +79,7 @@ public class AmbrosiumTorchArrow extends AbstractArrow {
                 if (direction == Direction.UP) {
                     setState = AetherBlocks.AMBROSIUM_TORCH.get().defaultBlockState();
                 } else {
-                    setState =  AetherBlocks.AMBROSIUM_TORCH.get().defaultBlockState().setValue(WallTorchBlock.FACING, direction);
+                    setState =  AetherBlocks.AMBROSIUM_WALL_TORCH.get().defaultBlockState().setValue(WallTorchBlock.FACING, direction);
                 }
 
                 if (setState.canSurvive(this.level(), finalPos)) {


### PR DESCRIPTION
As stated in Issue #8, Firing the Ambrosium Torch Arrow at a vertical surface resulted in a fatal Ticking Entity error. The logs described attempting to apply a direction to a block (in this case, `AMBROSIUM_TORCH`) that doesn't have directions. 

Upon further examination and research, I figured out that much like the regular Minecraft torch, there is a separate block to put when it's to be applied to a wall. The `onHitBlock` method has been corrected to now utilize the proper block when hitting vertical surfaces.